### PR TITLE
Vagrantfile and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You must always use the specified order:
 The software must be placed in `modules/software/files`. It must contain the next files:
 
 ### Puppet Enterprise
-- puppet-enterprise-2017.2.3-el-7-x86_64-x86_64.tar.gz (Extracted tar)
+- puppet-enterprise-2018.1.3-el-7-x86_64-x86_64.tar.gz (Extracted tar)
 
 ### JDK 1.5.2
 - jdk-8u152-linux-x64.tar.gz

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,8 @@ Vagrant.configure('2') do |config|
       srv.vm.synced_folder '.', '/vagrant', type: :virtualbox
       case server['type']
       when 'masterless'
-        srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box']
+        # srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box']
+        srv.vm.box = 'centos/7' unless server['box']
         config.trigger.after :up do |trigger|
           #
           # Fix hostnames because Vagrant mixes it up.
@@ -78,7 +79,7 @@ Vagrant.configure('2') do |config|
             trigger.run_remote = {inline: <<~EOD}
               cat > /etc/hosts<< "EOF"
               127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
-              192.168.253.10 master.example.com puppet master
+              192.168.253.10 wlsmaster.example.com puppet master
               #{server['public_ip']} #{hostname}.example.com #{hostname}
               EOF
               bash /vagrant/vm-scripts/install_puppet.sh
@@ -104,7 +105,8 @@ Vagrant.configure('2') do |config|
         end
 
       when 'pe-master'
-        srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box']
+        # srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box']
+        srv.vm.box = 'centos/7' unless server['box']
         srv.vm.synced_folder '.', '/vagrant', owner: pe_puppet_user_id, group: pe_puppet_group_id
         srv.vm.provision :shell, inline: "/vagrant/modules/software/files/#{puppet_installer} -c /vagrant/pe.conf -y"
         #
@@ -132,7 +134,8 @@ Vagrant.configure('2') do |config|
         srv.vm.provision :shell, inline: 'service pe-puppetserver restart'
         srv.vm.provision :shell, inline: 'puppet agent -t || true'
       when 'pe-agent'
-        srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box']
+        #srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box']
+        srv.vm.box = 'centos/7' unless server['box']
         #
         # First we need to instal the agent.
         #
@@ -144,7 +147,7 @@ Vagrant.configure('2') do |config|
             trigger.run_remote = {inline: <<~EOD}
               cat > /etc/hosts<< "EOF"
               127.0.0.1 localhost.localdomain localhost4 localhost4.localdomain4
-              192.168.253.10 master.example.com puppet master
+              192.168.253.10 wlsmaster.example.com puppet master
               #{server['public_ip']} #{hostname}.example.com #{hostname}
               EOF
               curl -k https://master.example.com:8140/packages/current/install.bash | sudo bash
@@ -163,7 +166,7 @@ Vagrant.configure('2') do |config|
             else
               trigger.run_remote = {inline: <<~EOD}
               Copy-Item -Path c:\\vagrant\\vm-scripts\\windows-hosts -Destination c:\\Windows\\System32\\Drivers\\etc\\hosts
-              [Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; $webClient = New-Object System.Net.WebClient; $webClient.DownloadFile('https://master.example.com:8140/packages/current/install.ps1', 'install.ps1');.\\install.ps1
+              [Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; $webClient = New-Object System.Net.WebClient; $webClient.DownloadFile('https://wlsmaster.example.com:8140/packages/current/install.ps1', 'install.ps1');.\\install.ps1
               iex 'puppet resource service puppet ensure=stopped'
               iex 'puppet agent -t'
               EOD
@@ -174,8 +177,8 @@ Vagrant.configure('2') do |config|
         # vb.gui = true
         vb.cpus = server['cpucount'] || 1
         vb.memory = server['ram'] || 4096
-        vb.customize ['modifyvm', :id, '--ioapic', 'on']
-        vb.customize ['modifyvm', :id, '--name', name]
+#        vb.customize ['modifyvm', :id, '--ioapic', 'on']
+#        vb.customize ['modifyvm', :id, '--name', name]
         if server['virtualboxorafix'] == 'enable'
           vb.customize ['setextradata', :id, 'VBoxInternal/CPUM/HostCPUID/Cache/Leaf', '0x4']
           vb.customize ['setextradata', :id, 'VBoxInternal/CPUM/HostCPUID/Cache/SubLeaf', '0x4']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,12 +65,12 @@ Vagrant.configure('2') do |config|
         config.winrm.ssl_peer_verification = false
         config.winrm.retry_delay = 60
         config.winrm.retry_limit = 10
-        end
+      end
       srv.vm.synced_folder '.', '/vagrant', type: :virtualbox
       case server['type']
       when 'masterless'
-        # srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box']
-        srv.vm.box = 'centos/7' unless server['box']
+        # srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box'] <- solves startup issues
+        srv.vm.box = 'centos/7' unless server['box'] # Used the distro default instead
         config.trigger.after :up do |trigger|
           #
           # Fix hostnames because Vagrant mixes it up.
@@ -79,7 +79,7 @@ Vagrant.configure('2') do |config|
             trigger.run_remote = {inline: <<~EOD}
               cat > /etc/hosts<< "EOF"
               127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
-              192.168.253.10 wlsmaster.example.com puppet master
+              192.168.253.10 wlsmaster.example.com puppet master # wlsmaster is what the module looks for
               #{server['public_ip']} #{hostname}.example.com #{hostname}
               EOF
               bash /vagrant/vm-scripts/install_puppet.sh
@@ -105,8 +105,8 @@ Vagrant.configure('2') do |config|
         end
 
       when 'pe-master'
-        # srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box']
-        srv.vm.box = 'centos/7' unless server['box']
+        # srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box'] <- solves startup issues
+        srv.vm.box = 'centos/7' unless server['box'] # Used the distro default instead
         srv.vm.synced_folder '.', '/vagrant', owner: pe_puppet_user_id, group: pe_puppet_group_id
         srv.vm.provision :shell, inline: "/vagrant/modules/software/files/#{puppet_installer} -c /vagrant/pe.conf -y"
         #
@@ -134,8 +134,8 @@ Vagrant.configure('2') do |config|
         srv.vm.provision :shell, inline: 'service pe-puppetserver restart'
         srv.vm.provision :shell, inline: 'puppet agent -t || true'
       when 'pe-agent'
-        #srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box']
-        srv.vm.box = 'centos/7' unless server['box']
+        #srv.vm.box = 'enterprisemodules/centos-7.3-x86_64-nocm' unless server['box'] <- solves startup issues
+        srv.vm.box = 'centos/7' unless server['box'] # Used the distro default instead
         #
         # First we need to instal the agent.
         #
@@ -147,7 +147,7 @@ Vagrant.configure('2') do |config|
             trigger.run_remote = {inline: <<~EOD}
               cat > /etc/hosts<< "EOF"
               127.0.0.1 localhost.localdomain localhost4 localhost4.localdomain4
-              192.168.253.10 wlsmaster.example.com puppet master
+              192.168.253.10 wlsmaster.example.com puppet master # wlamaster is what the module looks for
               #{server['public_ip']} #{hostname}.example.com #{hostname}
               EOF
               curl -k https://master.example.com:8140/packages/current/install.bash | sudo bash


### PR DESCRIPTION
In trying to get simple_wls_demo to launch, I kept running into a number of issues. 

Platform:
Mojave 10.14.3 build 18D109 0- 2018 MacBook Pro - 32G - Intel UHD Graphics 630 1536 MB with touch bar
VirtualBox Version 6.0.4 r128413 (Qt5.6.3)
VirtualBox Extensions 6.0.4r128413
Vagrant 2.2.3
Vagrant Plugins:
oscar (0.5.5, global)
vagrant-cachier (1.2.1, global)
vagrant-hosts (2.9.0, global)
vagrant-pe_build (0.18.2, global)
vagrant-share (1.1.9, global)
vagrant-vbguest (0.17.2, global)
Puppet 6.0.4

The Readme referenced one version of Puppet when the startup was looking for a different one. The Vagrantfile was creating a hosts file via a HEREDOC that made a "master.example.com", but the setup process was looking for "wlsmaster.example.com" so the setup never finished.

I've found a number of issues over the last couple years with the Puppet provided VMs, so I have defaulted to using the Official Distro repositories "centos/7" for instance.  I kept having repeated issues with the startup until this particular configuration.  This stands up on my system with the above specs without issue except for one remaining thing...  The call to the bash script to setup Puppet also fails but I didn't get to that yet.  

Finally, a call to vbox to customize the vm after creation fails, as the modifications already exist in the VM.  

You may not use any of this, or fix it in your own way, but I wanted to help if I could.